### PR TITLE
Fix: could not find function "v"

### DIFF
--- a/R/utility.R
+++ b/R/utility.R
@@ -148,7 +148,7 @@ scidbconnect = function(host=options("scidb.default_shim_host")[[1]],
 
 # Update the scidb.version option
   v = strsplit(gsub("[A-z\\-]", "", getOption("shim.version")), "\\.")[[1]]
-  if(length(v) < 2) v = v(v, "1")
+  if(length(v) < 2) v = c(v, "1")
   options(scidb.version=sprintf("%s.%s", v[1], v[2]))
 
 # Update the scidb.version option for older systems (shim version unreliable)


### PR DESCRIPTION
If the *true* branch of the `if` at [line 151](https://github.com/Paradigm4/SciDBR/blob/9faed7358adda8fea28ccaac5c57f12fa80218c2/R/utility.R#L151) is entered, you get:

```
> scidbconnect(host = SCIDB.HOST, port = SCIDB.PORT)
Error in scidbconnect(host = SCIDB.HOST, port = SCIDB.PORT) : 
  could not find function "v"
```

This patch fixes that.