### PR TITLE
scidbconnect when Shim port is forwarded

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -348,7 +348,12 @@ URI = function(db, resource="", args=list())
   if (!is.null(.scidbenv$username)) args = c(args, list(user=.scidbenv$username))
   prot = paste(.scidbenv$protocol, "//", sep=":")
   if ("password" %in% names(args) || "auth" %in% names(args)) prot = "https://"
-  ans  = paste(prot, .scidbenv$host, ":", .scidbenv$port, sep="")
+  if (!is.null(.scidbenv$port)) { # if port value is not NULL
+    ans = paste(prot, .scidbenv$host, ":", .scidbenv$port, sep="")
+  } else { # if port value is NULL, Shim port must have been forwarded to a URL
+           # and only having the URL is sufficient 
+    ans = paste(prot, .scidbenv$host, sep = "")
+  }
   ans = paste(ans, resource, sep="/")
   if (length(args)>0)
     ans = paste(ans, paste(paste(names(args), args, sep="="), collapse="&"), sep="?")

--- a/R/utility.R
+++ b/R/utility.R
@@ -66,7 +66,7 @@ scidb = function(db, name, gc=FALSE, schema)
 #' Connect to a SciDB database
 #' @param host optional host name or I.P. address of a SciDB shim service to connect to
 #' @param port optional port number of a SciDB shim service to connect to. For connecting
-#' to Shim behind an SSL connection, use \code{port= NULL} (see detailed note below). 
+#' to Shim when the Shim port is forwarded, use \code{port= NULL} (see detailed note below). 
 #' @param username optional authentication username
 #' @param password optional authentication password
 #' @param auth_type optional SciDB authentication type
@@ -94,12 +94,13 @@ scidb = function(db, name, gc=FALSE, schema)
 #' names, function signatures, and help strings, respectively. See
 #' `data("operators", package="scidb")` for an example.
 #' 
-#' \strong{Shim behind SSL}: Shim usually runs on a selected port e.g. 8080 or 8083
+#' \strong{Forwarded Shim port}: Shim usually runs on a selected port e.g. 8080 or 8083
 #' (for secure communication) and those ports need to be opened up to clients. In 
 #' other situations, the admin might decide to not open the Shim port and
 #' instead forward the Shim port to a URL like https://hostname/shim/. 
 #' In this case, we do not need to supply the port
-#' number during \code{scidbconnect()}; instead one should use \code{port = NULL}. 
+#' number during \code{scidbconnect()}; instead one should use \code{port = NULL}
+#' and \code{host=HOSTNAME/FORWARDED-PATH/}. 
 #'
 #' All arguments support partial matching.
 #' @return A scidb connection object. Use \code{$} to access AFL operators

--- a/R/utility.R
+++ b/R/utility.R
@@ -98,9 +98,8 @@ scidb = function(db, name, gc=FALSE, schema)
 #' (for secure communication) and those ports need to be opened up to clients. In 
 #' other situations, the admin might decide to not open the Shim port and
 #' instead forward the Shim port to a URL like https://hostname/shim/. 
-#' In this cases, we do not need to supply the port
-#' number during \code{scidbconnect()}. Instead one should use \code{port = NULL}  in this 
-#' case. 
+#' In this case, we do not need to supply the port
+#' number during \code{scidbconnect()}; instead one should use \code{port = NULL}. 
 #'
 #' All arguments support partial matching.
 #' @return A scidb connection object. Use \code{$} to access AFL operators

--- a/R/utility.R
+++ b/R/utility.R
@@ -65,7 +65,8 @@ scidb = function(db, name, gc=FALSE, schema)
 
 #' Connect to a SciDB database
 #' @param host optional host name or I.P. address of a SciDB shim service to connect to
-#' @param port optional port number of a SciDB shim service to connect to
+#' @param port optional port number of a SciDB shim service to connect to. For connecting
+#' to Shim behind an SSL connection, use \code{port= NULL} (see detailed note below). 
 #' @param username optional authentication username
 #' @param password optional authentication password
 #' @param auth_type optional SciDB authentication type
@@ -92,6 +93,14 @@ scidb = function(db, name, gc=FALSE, schema)
 #' character-valued columns name, signature, and help containing AFL operator
 #' names, function signatures, and help strings, respectively. See
 #' `data("operators", package="scidb")` for an example.
+#' 
+#' \strong{Shim behind SSL}: Shim usually runs on a selected port e.g. 8080 or 8083
+#' (for secure communication) and those ports need to be opened up to clients. In 
+#' other situations, the admin might decide to not open the Shim port and
+#' instead forward the Shim port to a URL like https://hostname/shim/. 
+#' In this cases, we do not need to supply the port
+#' number during \code{scidbconnect()}. Instead one should use \code{port = NULL}  in this 
+#' case. 
 #'
 #' All arguments support partial matching.
 #' @return A scidb connection object. Use \code{$} to access AFL operators

--- a/man/scidbconnect.Rd
+++ b/man/scidbconnect.Rd
@@ -13,7 +13,7 @@ scidbconnect(host = getOption("scidb.default_shim_host", "127.0.0.1"),
 \item{host}{optional host name or I.P. address of a SciDB shim service to connect to}
 
 \item{port}{optional port number of a SciDB shim service to connect to. For connecting
-to Shim behind an SSL connection, use \code{port= NULL} (see detailed note below).}
+to Shim when the Shim port is forwarded, use \code{port= NULL} (see detailed note below).}
 
 \item{username}{optional authentication username}
 
@@ -57,13 +57,13 @@ character-valued columns name, signature, and help containing AFL operator
 names, function signatures, and help strings, respectively. See
 `data("operators", package="scidb")` for an example.
 
-\strong{Shim behind SSL}: Shim usually runs on a selected port e.g. 8080 or 8083
+\strong{Forwarded Shim port}: Shim usually runs on a selected port e.g. 8080 or 8083
 (for secure communication) and those ports need to be opened up to clients. In 
 other situations, the admin might decide to not open the Shim port and
 instead forward the Shim port to a URL like https://hostname/shim/. 
-In this cases, we do not need to supply the port
-number during \code{scidbconnect()}. Instead one should use `port = NULL`  in this 
-case. 
+In this case, we do not need to supply the port
+number during \code{scidbconnect()}; instead one should use \code{port = NULL}
+and \code{host=HOSTNAME/FORWARDED-PATH/}. 
 
 All arguments support partial matching.
 }

--- a/man/scidbconnect.Rd
+++ b/man/scidbconnect.Rd
@@ -12,7 +12,8 @@ scidbconnect(host = getOption("scidb.default_shim_host", "127.0.0.1"),
 \arguments{
 \item{host}{optional host name or I.P. address of a SciDB shim service to connect to}
 
-\item{port}{optional port number of a SciDB shim service to connect to}
+\item{port}{optional port number of a SciDB shim service to connect to. For connecting
+to Shim behind an SSL connection, use \code{port= NULL} (see detailed note below).}
 
 \item{username}{optional authentication username}
 
@@ -56,6 +57,14 @@ character-valued columns name, signature, and help containing AFL operator
 names, function signatures, and help strings, respectively. See
 `data("operators", package="scidb")` for an example.
 
+\strong{Shim behind SSL}: Shim usually runs on a selected port e.g. 8080 or 8083
+(for secure communication) and those ports need to be opened up to clients. In 
+other situations, the admin might decide to not open the Shim port and
+instead forward the Shim port to a URL like https://hostname/shim/. 
+In this cases, we do not need to supply the port
+number during \code{scidbconnect()}. Instead one should use `port = NULL`  in this 
+case. 
+
 All arguments support partial matching.
 }
 \examples{
@@ -84,4 +93,3 @@ as.R(y)   # Download a SciDB array to R.
 \seealso{
 \code{\link{scidb_prefix}}
 }
-


### PR DESCRIPTION
@bwlewis At a particular client site, the IT admin did not want to expose `hostname:8083`. Instead they chose to forward this port via Apache server to `https://hostname/shim/`. 

In such a case, `scidbconnect()` can be called as follows:
```R
scidbconnect(protocol = 'https', host = 'hostname/shim/', port = NULL)
```
The changes in this pull request enable a NULL value of `port` to be passed through. Otherwise a `:` is added to the URL. 

PS: This is a clone of pull request #174. I closed that one, and opened this one instead. 