### PR TITLE
Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,24 @@
+# blocklist
+branches:
+  except:
+  - discontinued_master 
+
 sudo: required
 
 language: r 
+cache: packages
+
+addons:
+  apt:
+    packages:
+      - pandoc
+      - libxml2-dev
 
 r:
   - release
+
+#r_packages:
+#  - knitr
 
 env: SCIDB_VER=16.9
 
@@ -22,12 +37,21 @@ before_install:
     rvernica/scidb:${SCIDB_VER}
   - while ! curl http://localhost:8080/version; do sleep 1; done
 
+# install:
+#   - R --slave -e "install.packages(c('knitr', 'bit64', 'curl', 'data.table', 'openssl'))"
+#   - cd ..
+#   - R CMD build SciDBR 
+
+# script:
+#   - SCIDB_TEST_HOST=127.0.0.1 R CMD check scidb_*.tar.gz
+
 install:
-  - git clone https://github.com/ksens/scidbr.git
-  - R CMD build scidbr 
+  - R -e "install.packages(c('knitr', 'bit64', 'curl', 'data.table', 'openssl', 'devtools'))"
+  - R -e 'devtools::install_deps(dep = T)'
 
 script:
-  - SCIDB_TEST_HOST=127.0.0.1 R CMD check scidb_2.0.0.tar.gz
+  - R CMD build .
+  - SCIDB_TEST_HOST=127.0.0.1 R CMD check *tar.gz
 
 after_failure:
   - docker logs scidb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+sudo: required
+
+language: r 
+
+r:
+  - release
+
+env: SCIDB_VER=16.9
+
+services:
+  - docker
+
+before_install:
+  - docker pull rvernica/scidb:${SCIDB_VER}
+  - docker run
+    --name scidb
+    --detach
+    --volume /dev/shm
+    --tmpfs /dev/shm:exec
+    --publish 8080:8080
+    --publish 8083:8083
+    rvernica/scidb:${SCIDB_VER}
+  - while ! curl http://localhost:8080/version; do sleep 1; done
+
+install:
+  - git clone https://github.com/ksens/scidbr.git
+  - R CMD build scidbr 
+
+script:
+  - SCIDB_TEST_HOST=127.0.0.1 R CMD check scidb_2.0.0.tar.gz
+
+after_failure:
+  - docker logs scidb


### PR DESCRIPTION
Based on scidb travis integration by @rvernica at https://github.com/Paradigm4/SciDB-Py/blob/master/.travis.yml, I created a `.travis.yml` file for scidbr. 

I have tested this in my own travis-ci account https://travis-ci.org/ksens/SciDBR/builds. 

Next, I will merge this into `paradigm4/scidbr`, and test with Paradigm4 group's Travis CI account https://travis-ci.org/Paradigm4/SciDBR. 

Eventually this should help resolve outstanding issues in #175, #179. 