### PR TITLE
Enable scidb v19 support for aio_input and bug fix

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -705,7 +705,7 @@ df2scidb = function(db, X,
     else if (grepl("^int", typ[j]) || "integer64" %in% class(X[, j]))
     {
       if(is.null(types)) typ[j] = "int64"
-      X[, j] = gsub("NA", "null", as.character(X[, j]))
+      X[, j] = gsub("NA", "null",  sprintf("%s", X[, j]))
     }
     else if ("logical" %in% class(X[, j]))
     {

--- a/R/internal.R
+++ b/R/internal.R
@@ -294,6 +294,27 @@ create_temp_array = function(db, name, schema)
   iquery(db, query, `return`=FALSE)
 }
 
+# Internal function
+get_setting_items_str = function(settings, sep=',') {
+  
+  convert_single_item_v19 = function(key, value) {
+    if(is.character(value))
+      value = sprintf("'%s'", value)  # Quote string value(s)
+    valueStr = if(length(value) > 1) sprintf("(%s)", paste(value, collapse = ',')) else value
+    
+    sprintf("%s:%s", key, valueStr)
+  } 
+  convert_single_item_pre_v19 = function(key, value) {
+    valueStr = if(length(value) > 1) paste(value, collapse = ',') else value
+    sprintf("'%s=%s'", key, valueStr)
+  } 
+  
+  convert_single_item = if (at_least(attr(db, "connection")$scidb.version, "19.0")) 
+    convert_single_item_v19 else convert_single_item_pre_v19
+  
+  items = mapply(convert_single_item, names(settings), settings)
+  paste(items, collapse = sep)
+}
 
 #' An important internal convenience function that returns a scidb object.  If
 #' eval=TRUE, a new SciDB array is created the returned scidb object refers to
@@ -763,12 +784,11 @@ df2scidb = function(db, X,
   atts = paste(dcast, collapse=",")
   if (use_aio_input && aio)
   {
-    if (missing(chunk_size))
-      LOAD = sprintf("project(apply(aio_input('%s','num_attributes=%d'),%s),%s)", tmp,
-                 ncolX, atts, paste(anames, collapse=","))
-    else
-      LOAD = sprintf("project(apply(aio_input('%s','num_attributes=%d','chunk_size=%.0f'),%s),%s)", tmp,
-                 ncolX, chunk_size, atts, paste(anames, collapse=","))
+    aioSettings = list(num_attributes = ncolX)
+    if(!missing(chunk_size))
+      aioSettings[['chunk_size']] = chunk_size
+    LOAD = sprintf("project(apply(aio_input('%s', %s),%s),%s)", tmp,
+               get_seeting_items_str(aioSettings), atts, paste(anames, collapse=","))
   } else
   {
     if (missing(chunk_size))

--- a/R/internal.R
+++ b/R/internal.R
@@ -295,7 +295,7 @@ create_temp_array = function(db, name, schema)
 }
 
 # Internal function
-get_setting_items_str = function(settings, sep=',') {
+get_setting_items_str = function(db, settings, sep=',') {
   
   convert_single_item_v19 = function(key, value) {
     if(is.character(value))
@@ -788,7 +788,7 @@ df2scidb = function(db, X,
     if(!missing(chunk_size))
       aioSettings[['chunk_size']] = chunk_size
     LOAD = sprintf("project(apply(aio_input('%s', %s),%s),%s)", tmp,
-                   get_setting_items_str(aioSettings), atts, paste(anames, collapse=","))
+                   get_setting_items_str(db, aioSettings), atts, paste(anames, collapse=","))
   } else
   {
     if (missing(chunk_size))

--- a/R/internal.R
+++ b/R/internal.R
@@ -788,7 +788,7 @@ df2scidb = function(db, X,
     if(!missing(chunk_size))
       aioSettings[['chunk_size']] = chunk_size
     LOAD = sprintf("project(apply(aio_input('%s', %s),%s),%s)", tmp,
-               get_seeting_items_str(aioSettings), atts, paste(anames, collapse=","))
+                   get_setting_items_str(aioSettings), atts, paste(anames, collapse=","))
   } else
   {
     if (missing(chunk_size))


### PR DESCRIPTION
- Make aio_input in as.scidb function work in scidb V19+ where the syntax of aio params has changed
- Fix a bug that caused uploading a data frame with NA integer64 to fail. Reason: as.character cannot coerce NA values to "NA" strings.