### PR TITLE
Fix CRAN warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: scidb
 Type: Package
 Title: An R Interface to SciDB
-Version: 3.0.0
-Date: 2020-8-6
+Version: 3.0.1
+Date: 2020-10-12
 Authors@R: c(
     person("Kriti", "Sen Sharma", role=c("cre", "aut"), email="ksen@paradigm4.com"),
     person("B. W.", "Lewis", role=c("aut"), email="blewis@illposed.net"),

--- a/R/internal.R
+++ b/R/internal.R
@@ -774,8 +774,8 @@ df2scidb = function(db, X,
 
   ncolX = ncol(X)
   nrowX = nrow(X)
-  if(missing(format)) X = charToRaw(fwrite(X, file=return))
-  else X = charToRaw(fwrite(X, file=return, format=format))
+  if(missing(format)) X = charToRaw(fwrite(X, file=.Primitive("return")))
+  else X = charToRaw(fwrite(X, file=.Primitive("return"), format=format))
   tmp = POST(db, X, list(id=session))
   tmp = gsub("\n", "", gsub("\r", "", tmp))
 
@@ -814,7 +814,7 @@ df2scidb = function(db, X,
 #' Not such a great option for writing to files, marginal difference from write.table and
 #' obviously much greater memory use.
 #' @param x a data frame
-#' @param file a connection or \code{return} to return character output directly (fast)
+#' @param file a connection or \code{.Primitive("return")} to return character output directly (fast)
 #' @param sep column separator
 #' @param format optional fprint-style column format specifyer
 #' @return Use for the side effect of writing to the connection returning \code{NULL}, or

--- a/man/fwrite.Rd
+++ b/man/fwrite.Rd
@@ -14,7 +14,7 @@ fwrite(
 \arguments{
 \item{x}{a data frame}
 
-\item{file}{a connection or \code{return} to return character output directly (fast)}
+\item{file}{a connection or \code{.Primitive("return")} to return character output directly (fast)}
 
 \item{sep}{column separator}
 


### PR DESCRIPTION
@bwlewis 

I had received the following email notification from CRAN maintainers:

> A new check in R-devel (part of --as-cran) looks for return without ():
> this is reported on the CRAN results pages for fedora-clang and fedora-gcc.
> 
> Please check the report for your package and either submit a correction
> before Oct 1 or let us know that you think this is a false positive.

I missed the October 1 deadline as a result of which SciDBR was archived from CRAN :(. In this branch, I worked on the necessary fix, and the specific warning is not seen anymore. 

Could you please review. 

PS: I have submitted the tar.gz to https://win-builder.r-project.org/upload.aspx and am awaiting the results. 