### PR TITLE
Fix #215

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -721,7 +721,7 @@ df2scidb = function(db, X,
     else if (grepl("^int64", typ[j]) || "integer64" %in% class(X[, j]))
     {
       if(is.null(types)) typ[j] = "int64"
-      X[, j] = gsub("NA", "null",  sprintf("%s", X[, j]))
+      X[, j] = gsub("NA", "null",  sprintf("%s", bit64::as.integer64(X[, j])))
     }
     else if (grepl("^int", typ[j]) || "integer" %in% class(X[, j]))
     {


### PR DESCRIPTION


```r
# Issue 215

# Explicit types
a = data.frame( x= as.numeric(1000000), y =128) 
x = scidb::as.scidb(db, a, types=c('int64', 'int64'))
x@meta$schema
# "<x:int64,y:int64> [i=1:1:0:10000]"

# Implicit types also work
a2 = data.frame( x = bit64::as.integer64(64), y = as.integer(32), z = 3.14 )
x2 = scidb::as.scidb(db, a2)
x2@meta$schema
# "<x:int64,y:int32,z:double> [i=1:1:0:10000]"
```

Related issue #211

