### PR TITLE
fix for storing character columns containing NA values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scidb
 Type: Package
 Title: An R Interface to SciDB
-Version: 3.0.3
+Version: 3.0.4
 Date: 2021-05-13
 Authors@R: c(person(given = "Kriti",     family = "Sen Sharma",  role=c("cre", "aut"),   email="ksen@paradigm4.com"),
              person(given = "B. W.",     family = "Lewis",       role = "aut",           email = "blewis@illposed.net"),

--- a/src/scidb.c
+++ b/src/scidb.c
@@ -102,6 +102,7 @@ scidb_raw (SEXP A)
   unsigned int slen, l;
   const unsigned char not_missing = NOT_MISSING;
   const char missing = IS_MISSING;
+  const char na_string[] = {0,0,0,0,0};
   switch (TYPEOF (A))
     {
     case REALSXP:
@@ -178,9 +179,9 @@ scidb_raw (SEXP A)
       for (j = 0; j < len; ++j)
         {
           if (STRING_ELT (A, j) == NA_STRING)
-            slen = slen + 4 + 1 + 1;
+            slen = slen + 1 + 4;
           else
-            slen = slen + 4 + 1 + 1 + strlen (CHAR (STRING_ELT (A, j)));
+            slen = slen + 1 + 4 + strlen (CHAR (STRING_ELT (A, j))) + 1;
         }
       PROTECT (ans = allocVector (RAWSXP, slen));
       buf = (char *) RAW (ans);
@@ -200,8 +201,8 @@ scidb_raw (SEXP A)
             }
           else
             {
-              memcpy (buf, &missing, 1);
-              buf += 6;
+              memcpy (buf, &na_string, 5);
+              buf += 5;
             }
         }
       break;


### PR DESCRIPTION
Small fix for storing character columns/vectors with NAs. Tested with SciDB 19.11.

This would fail:

```R
options(scidb.debug=T)
a = c('bender', NA, 'flexo')
b = scidb::as.scidb(db, a)
```

Now it works. Plus a little space savings on memory allocation when there are NA values and update point release value.