### PR TITLE
digest_auth future-proofing

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -241,8 +241,8 @@ digest_auth = function(db, method, uri, realm="", nonce="123456")
   user = up[1]
   pwd  = up[2]
   if (is.na(pwd)) pwd=""
-  ha1=digest(sprintf("%s:%s:%s", user, realm, pwd, algo="md5"), serialize=FALSE)
-  ha2=digest(sprintf("%s:%s", method,  uri, algo="md5"), serialize=FALSE)
+  ha1=digest(sprintf("%s:%s:%s", user, realm, pwd), algo="md5", serialize=FALSE)
+  ha2=digest(sprintf("%s:%s", method,  uri), algo="md5", serialize=FALSE)
   cnonce="MDc1YmFhOWFkY2M0YWY2MDAwMDBlY2JhMDAwMmYxNTI="
   nc="00000001"
   qop="auth"


### PR DESCRIPTION
- `internal.R`>`digest_auth`>lines 244-245: rearranged parentheses for `sprintf` to exclude the `algo` parameter. more info below.

`algo` is listed as a parameter within `sprintf`, and not as a parameter in digest. In R<4.0, `sprintf` allowed '...' parameters, but wouldn't do anything with those extra parameters. However, in R>=4.0, sprintf became more strict, only allowing the same number of parameters as there were substitutions in the given string(yielding a warning/error otherwise).

Why this issue matters is, if you have R>=4.0 and want to set up a local instance, running `scidbconnect()` would fail because the response would be the very warning message that `sprintf` gives you for adding more parameters than substitutions. In turn, you can't establish a proper local connection to scidb. Allowing this change will make this part of the package "future(and past)-proof" to R versions