### PR TITLE
Adding support for SciDB data.frame in SciDBR.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,71 @@
+name: Test Suite
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        SCIDB_VER: [19.11]
+        OS: [xenial, centos-7]
+        R: [ '3.5.3', '3.6.1' ]
+
+    services:
+      scidb:
+        image: ghcr.io/rvernica/scidb:${{ matrix.SCIDB_VER }}-${{ matrix.OS }}
+        volumes:
+          - /dev/shm
+          - /sys/fs/cgroup:/sys/fs/cgroup
+          - /tmp/$(mktemp --directory):/run
+        ports:
+          - 8080:8080
+          - 8083:8083
+        options: --name scidb
+
+    steps:
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: ${{ matrix.R }}
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Start SciDB in CentOS-7
+        run: >-
+          docker exec scidb
+          /opt/scidb/${{ matrix.SCIDB_VER }}/bin/scidbctl.py start scidb
+        if: ${{ matrix.OS == 'centos-7' }}
+
+      - name: Start Shim in CentOS-7
+        run: docker exec scidb systemctl start shimsvc
+        if: ${{ matrix.OS == 'centos-7' }}
+
+      - name: Wait for SciDB to start
+        run: while ! curl http://localhost:8080/version; do sleep 5; done
+
+      - name: Install Basic dependencies
+        run: install.packages(c("remotes", "rcmdcheck"))
+        shell: Rscript {0}
+
+      - name: Install OS dependencies
+        run: |
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <( Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+
+      - name: Install SciDB-R dependencies
+        run: remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+
+      - name: Build and check
+        env:
+          SCIDB_TEST_HOST: 127.0.0.1
+        run: |
+          options(crayon.enabled = TRUE)
+          rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "error")
+        shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scidb
 Type: Package
 Title: An R Interface to SciDB
-Version: 3.0.4
+Version: 3.0.5
 Date: 2021-05-13
 Authors@R: c(person(given = "Kriti",     family = "Sen Sharma",  role=c("cre", "aut"),   email="ksen@paradigm4.com"),
              person(given = "B. W.",     family = "Lewis",       role = "aut",           email = "blewis@illposed.net"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## Version 3.0.6
+
+- Date: 2021-08-13
+- In `as.R`, SciDB data frames are downloaded without the artificial dimensions 
+
 ## Version 3.0.5
 
 - Date: 2021-07-20

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![CRAN version](http://www.r-pkg.org/badges/version/scidb)](https://cran.r-project.org/package=scidb)
 ![](http://cranlogs.r-pkg.org/badges/scidb)
 [![codecov.io](https://codecov.io/github/Paradigm4/SciDBR/coverage.svg?branch=master)](https://codecov.io/github/Paradigm4/SciDBR?branch=master)
+[![Test Suite](https://github.com/Paradigm4/SciDBR/actions/workflows/test.yml/badge.svg)](https://github.com/Paradigm4/SciDBR/actions/workflows/test.yml)
 
 Install the package from CRAN with
 ```

--- a/tests/a.R
+++ b/tests/a.R
@@ -295,6 +295,10 @@ if (nchar(host) > 0) {
   check(scidb_df, scidb_ret)
   # Delete SciDB dataframe
   iquery(db, sprintf('remove(%s)', scidb_df_name))
+  # Check an SciDB dataframe created from an array with a single dimension
+  scidb_ret <- iquery(db, 'flatten(build(<value:double>[i=1:5:0:1], iif(i%2=0, 1, 0)))', return=T)
+  scidb_ret <- scidb_ret[order(scidb_ret$i),]
+  check(scidb_ret, data.frame(i = 1:5, value = abs(floor(1:5%%2) -1), stringsAsFactors = FALSE))
 }
 
 message("Ran tests in: ", (proc.time()-t1)[[3]], " seconds")

--- a/tests/a.R
+++ b/tests/a.R
@@ -275,6 +275,26 @@ if (nchar(host) > 0) {
   # Restoring global options
   options(scidb.max_byte_size = initial.max_byte_size)
   options(scidb.result_size_limit = initial.result_size_limit)
+  
+# Issue 224 Support for SciDB dataframe
+  scidb_df_name = 'scidb_df_flat_test'
+  scidb_df = data.frame(i=c(rep(1,3), rep(2,3), rep(3,3)), j=rep(1:3, 3), stringsAsFactors = FALSE)
+  scidb_df$value = as.numeric(scidb_df$i == scidb_df$j)
+  # create a SciDB dataframe 
+  iquery(db, 
+         sprintf("store(flatten(build(<value:double>[i=1:3:0:1, j=1:3:0:1], iif(i=j, 1, 0))), %s)", 
+                 scidb_df_name)
+         )
+  # check iquery
+  scidb_ret <- iquery(db, sprintf('scan(%s)', scidb_df_name), return = TRUE)
+  scidb_ret <- scidb_ret[order(scidb_ret$i, scidb_ret$j),]
+  check(scidb_df, scidb_ret)
+  # check as.R
+  scidb_ret <- as.R(scidb(db, scidb_df_name))
+  scidb_ret <- scidb_ret[order(scidb_ret$i, scidb_ret$j),]
+  check(scidb_df, scidb_ret)
+  # Delete SciDB dataframe
+  iquery(db, sprintf('remove(%s)', scidb_df_name))
 }
 
 message("Ran tests in: ", (proc.time()-t1)[[3]], " seconds")


### PR DESCRIPTION
Modifying the function `lazyeval` to return query distribution along with query schema. This allows to check if a dataframe object is requested via query and modify the only_attributes parameter to TRUE.

Also, adding a test for the above modification.