### PR TITLE
Fix for datetime on machines that don't have same TZ as server

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -216,7 +216,7 @@ scidb_unpack_to_dataframe = function(db, query, ...)
     for (i64 in which(internal_attributes$type %in% "int64")) oldClass(ans[, i64]) = "integer64"
   }
   # Handle datetime (integer POSIX time)
-  for (idx in which(internal_attributes$type %in% "datetime")) ans[, idx] = as.POSIXct(ans[, idx], origin="1970-1-1")
+  for (idx in which(internal_attributes$type %in% "datetime")) ans[, idx] = as.POSIXct(ans[, idx], origin="1970-1-1", tz = "GMT")
   if (args$only_attributes) # permute cols, see issue #125
   {
     colnames(ans) = make.names_(attributes$name)


### PR DESCRIPTION
In testing arrayop on a different machine, ran into a case where datetime objects were being returned shifted to the current time zone. Because the `datetime` object is explicitly UTC, added the time zone to the data being returned via SciDBR.